### PR TITLE
add youtube videos to past seminars

### DIFF
--- a/content/2020-02-26-socratic-seminar-07.md
+++ b/content/2020-02-26-socratic-seminar-07.md
@@ -3,6 +3,7 @@ title = "Will Reeves and Bitcoin Socratic Seminar #7"
 template = "post.html"
 [extra]
 meetup_id = "268296785"
+youtube_id = "pNYtLCm6GRI"
 +++
 
 ### Agenda

--- a/content/2020-03-19-socratic-seminar-08.md
+++ b/content/2020-03-19-socratic-seminar-08.md
@@ -3,6 +3,7 @@ title = "Mark 'Murch' Erhardt and Bitcoin Socratic Seminar #8"
 template = "post.html"
 [extra]
 meetup_id = "268301778"
+youtube_id = "zYrBrSHCPCY"
 +++
 
 ### Agenda

--- a/content/2020-04-16-socratic-seminar-09.md
+++ b/content/2020-04-16-socratic-seminar-09.md
@@ -3,6 +3,7 @@ title = "Amiti Uttarwar and Bitcoin Socratic Seminar #9"
 template = "post.html"
 [extra]
 meetup_id = "269265962"
+youtube_id = "8TaY730YlMg"
 +++
 
 ### Agenda

--- a/content/2020-05-21-socratic-seminar-10.md
+++ b/content/2020-05-21-socratic-seminar-10.md
@@ -3,6 +3,7 @@ title = "Alekos Filini and Bitcoin Socratic Seminar #10"
 template = "post.html"
 [extra]
 meetup_id = "270003487"
+youtube_id = "QVhC2DOIl7I"
 +++
 
 ### Agenda

--- a/content/2020-06-18-socratic-seminar-11.md
+++ b/content/2020-06-18-socratic-seminar-11.md
@@ -3,6 +3,7 @@ title = "Luke Dashjr and Bitcoin Socratic Seminar #11"
 template = "post.html"
 [extra]
 meetup_id = "270812619"
+youtube_id = "CojixIMgg3c"
 +++
 
 ### Agenda  

--- a/content/2020-07-22-socratic-seminar-12.md
+++ b/content/2020-07-22-socratic-seminar-12.md
@@ -3,6 +3,7 @@ title = "Tankred Hase and Bitcoin Socratic Seminar #12"
 template = "post.html"
 [extra]
 meetup_id = "271520867"
+youtube_id = "N1c_AJg2jkY"
 +++
 
 ### Agenda  

--- a/content/2020-08-20-socratic-seminar-13.md
+++ b/content/2020-08-20-socratic-seminar-13.md
@@ -3,6 +3,7 @@ title = "RGB Lightning and Bitcoin Socratic Seminar #13"
 template = "post.html"
 [extra]
 meetup_id = "272339225"
+youtube_id = "Mkidb0wjua0"
 +++
 
 ### Agenda  

--- a/templates/post.html
+++ b/templates/post.html
@@ -13,6 +13,12 @@
             </span>
             {% endif %}
         </div>
+        {% if page.extra.youtube_id %}
+        <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/{{ page.extra.youtube_id }}"
+                frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen></iframe>
+        {% endif %}
+
         <div class="Post-content">{{ page.content | safe }}</div>
     </div>
 </section>


### PR DESCRIPTION
Seminar pages that have youtube videos look like this:

<img width="1590" alt="Screen Shot 2020-08-27 at 2 41 22 PM" src="https://user-images.githubusercontent.com/4724730/91497819-82b4ee00-e873-11ea-9543-7ab938fac45d.png">
